### PR TITLE
Fix API routes import path in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const { applySecurityMiddleware } = require('./backend/middleware/securityMiddle
 
 // Application modules
 const db = require('./backend/db/connection');
-const apiRoutes = require('./backend/routes');
+const apiRoutes = require('./backend/routes/api');
 const logger = require('./backend/services/logger');
 const jobQueue = require('./backend/services/jobQueue');
 


### PR DESCRIPTION
- Changed the import from './backend/routes' to './backend/routes/api' to match the actual file structure
- This fixes the deployment error 'Cannot find module ./backend/routes'
- The main API routes file is actually located at 'backend/routes/api.js'

Co-authored-by: joeyickesllc