### PR TITLE
Fix Express 5.x compatibility issues

### DIFF
--- a/backend/middleware/securityMiddleware.js
+++ b/backend/middleware/securityMiddleware.js
@@ -34,8 +34,19 @@ exports.applySecurityMiddleware = (app) => {
     crossOriginResourcePolicy: { policy: 'cross-origin' } // Allow cross-origin resource sharing
   }));
 
-  // Prevent XSS attacks
-  app.use(xssClean());
+  /*
+   * ---------------------------------------------------------------------------
+   * X-XSS Protection
+   * ---------------------------------------------------------------------------
+   * `xss-clean@0.1.4` mutates `req.query` which became read-only in Express 5.
+   * This results in the runtime error:
+   *     "TypeError: Cannot set property query of #<IncomingMessage>..."
+   *
+   * Until a compatible version (or alternative middleware) is available we
+   * temporarily disable xss-clean to keep the application functional.  Basic
+   * protection is still provided by Helmet’s built-in X-XSS-Protection header.
+   */
+  logger.warn('xss-clean middleware disabled – incompatible with Express 5.x');
 
   // Apply global rate limiting
   app.use(
@@ -59,7 +70,7 @@ exports.applySecurityMiddleware = (app) => {
 
   logger.info('Security middleware applied', {
     helmet: true,
-    xssProtection: true,
+    xssProtection: false, // Temporarily disabled (see note above)
     rateLimit: true
   });
 };

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const { applySecurityMiddleware } = require('./backend/middleware/securityMiddle
 
 // Application modules
 const db = require('./backend/db/connection');
-const apiRoutes = require('./backend/routes');
+const apiRoutes = require('./backend/routes/api');
 const logger = require('./backend/services/logger');
 const jobQueue = require('./backend/services/jobQueue');
 
@@ -42,6 +42,9 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const IS_PRODUCTION = NODE_ENV === 'production';
 const IS_RENDER = process.env.RENDER === 'true';
 const SESSION_SECRET = process.env.SESSION_SECRET || 'collectflo-dev-secret';
+
+// HTTP server instance for graceful shutdown
+let server;
 
 // Create Express app
 const app = express();
@@ -207,8 +210,8 @@ async function startServer() {
     // Run database migrations
     await runMigrations();
     
-    // Start the server
-    app.listen(PORT, () => {
+    // Start the server and keep a reference for graceful shutdown
+    server = app.listen(PORT, () => {
       logger.info(`CollectFlo server listening on port ${PORT} in ${NODE_ENV} mode`);
     });
 


### PR DESCRIPTION
- Disabled xss-clean middleware which is incompatible with Express 5.x (trying to set read-only req.query property)
- Added server variable declaration to fix 'server is not defined' error in graceful shutdown
- Updated logging to indicate that XSS protection is temporarily disabled

Co-authored-by: joeyickesllc