### PR TITLE
Fix signup form field names for consistency

### DIFF
--- a/public/signup.html
+++ b/public/signup.html
@@ -138,7 +138,9 @@
       
       const formData = {
         company_name: document.getElementById('company_name').value.trim(),
+        companyName:  document.getElementById('company_name').value.trim(), // camelCase alias for backend validator
         name: document.getElementById('name').value.trim(),
+        fullName:     document.getElementById('name').value.trim(),        // camelCase alias for backend validator
         email: document.getElementById('email').value.trim(),
         password: document.getElementById('password').value
       };


### PR DESCRIPTION
- Added both snake_case and camelCase form field names to match backend validation
- Form now includes both 'name' and 'fullName' fields
- Form now includes both 'company_name' and 'companyName' fields
- This ensures proper field validation and alignment with the backend

Co-authored-by: joeyickesllc