### PR TITLE
Add cookie-parser and jsonwebtoken to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
     "helmet": "^8.1.0",
+    "cookie-parser": "^1.4.6",
+    "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.2",
     "node-pg-migrate": "^6.2.2",


### PR DESCRIPTION
Fixes deployment issue where dependencies were installed locally but not added to package.json.