### PR TITLE
Fix queue name in scheduler job

### DIFF
--- a/services/scheduler.js
+++ b/services/scheduler.js
@@ -51,7 +51,7 @@ function initScheduler() {
       logger.info('Running scheduled invoice sync');
       try {
         // Queue the sync job to be processed by the job queue
-        await jobQueue.add('syncInvoices', {
+        await jobQueue.add('sync', {
           timestamp: new Date().toISOString()
         });
         logger.info('Invoice sync job queued successfully');


### PR DESCRIPTION
## Summary
- use the existing `sync` queue when scheduling the daily invoice sync job

## Testing
- `npm test --silent` *(fails: Beta Controller, Auth Controller unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ea2e858408320849ba0ffd49a5439