### PR TITLE
Fix secure cookie handling in sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,9 @@ app.use(session({
   saveUninitialized: true,
   // MemoryStore is automatically used when no `store` provided
   cookie: {
-    secure: IS_PRODUCTION,
+    // Use per-request HTTPS detection so sessions also work over HTTP in
+    // local development while remaining secure in production behind TLS.
+    secure: 'auto',
     httpOnly: true,
     sameSite: 'lax',
     path: '/',


### PR DESCRIPTION
## Summary
- make express-session use per-request HTTPS detection

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687eb0c1def48320beb3d00b38997a73