### PR TITLE
Fix auth route validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules/
 *.sqlite
 .DS_Store
 .replit
-.git
+coverage/

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -10,13 +10,19 @@ const router = express.Router();
 const authController = require('../controllers/authController');
 const jwtAuthMiddleware = require('../middleware/jwtAuthMiddleware');
 const logger = require('../services/logger');
+const {
+  authRateLimiter,
+  signupRateLimiter,
+  validateLogin,
+  validateSignup
+} = require('../middleware/securityMiddleware');
 
 /**
  * @route   POST /api/auth/login
  * @desc    Authenticate user & get tokens
  * @access  Public
  */
-router.post('/login', async (req, res) => {
+router.post('/login', authRateLimiter, validateLogin, async (req, res) => {
   try {
     await authController.login(req, res);
   } catch (error) {
@@ -33,7 +39,7 @@ router.post('/login', async (req, res) => {
  * @desc    Register a new user
  * @access  Public
  */
-router.post('/signup', async (req, res) => {
+router.post('/signup', signupRateLimiter, validateSignup, async (req, res) => {
   try {
     await authController.signup(req, res);
   } catch (error) {

--- a/backend/tests/unit/routes/authRoutes.test.js
+++ b/backend/tests/unit/routes/authRoutes.test.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const request = require('supertest');
+
+const authRoutes = require('../../../routes/authRoutes');
+
+jest.mock('../../../controllers/authController', () => ({
+  login: jest.fn((req, res) => res.status(200).json({ success: true })),
+  signup: jest.fn((req, res) => res.status(201).json({ success: true })),
+  logout: jest.fn(),
+  checkAuth: jest.fn(),
+  changePassword: jest.fn()
+}));
+
+const authController = require('../../../controllers/authController');
+
+describe('Auth Routes - Middleware', () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/auth', authRoutes);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POST /api/auth/login validates input', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ password: 'pass' });
+
+    expect(res.status).toBe(400);
+    expect(authController.login).not.toHaveBeenCalled();
+  });
+
+  test('POST /api/auth/signup validates input', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({
+        companyName: 'TestCo',
+        fullName: 'T',
+        password: 'password'
+      });
+
+    expect(res.status).toBe(400);
+    expect(authController.signup).not.toHaveBeenCalled();
+  });
+
+  test('valid login passes to controller', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({
+        email: 'user@example.com',
+        password: 'password123'
+      });
+
+    expect(res.status).toBe(200);
+    expect(authController.login).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- apply rate limiting and validation middleware to `/api/auth/login` and `/api/auth/signup`
- test auth route middleware with supertest
- ignore coverage artifacts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687eb73f8bd08320b4fc86b0dd9ff72f