### PR TITLE
Fix JWT cookie persistence on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # CollectFlo_GitHub_Ready
 
+
+## Auth Updates
+
+The login endpoint now persists JWT tokens in HTTP-only cookies so the session remains authenticated after redirecting to /dashboard.

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -65,17 +65,20 @@ exports.login = async (req, res) => {
     // ------------------------------------------------------------------
     // Generate JWT tokens & set secure cookies
     // ------------------------------------------------------------------
-let accessToken, refreshToken;
-try {
-  accessToken  = jwtService.generateAccessToken(user);
-  refreshToken = jwtService.generateRefreshToken(user);
-} catch (tokenErr) {
-  logger.error('JWT generation failed during login', { error: tokenErr });
-  return res.status(500).json({
-    success : false,
-    message : 'Authentication error – please try again later'
-  });
-}
+    let accessToken, refreshToken;
+    try {
+      accessToken  = jwtService.generateAccessToken(user);
+      refreshToken = jwtService.generateRefreshToken(user);
+    } catch (tokenErr) {
+      logger.error('JWT generation failed during login', { error: tokenErr });
+      return res.status(500).json({
+        success : false,
+        message : 'Authentication error – please try again later'
+      });
+    }
+
+    // Persist tokens in HTTP-only cookies so subsequent requests are authenticated
+    setAuthCookies(req, res, accessToken, refreshToken);
 
     // Create session for backwards compatibility with session-based code
     req.session.user = {

--- a/backend/tests/unit/controllers/authController.test.js
+++ b/backend/tests/unit/controllers/authController.test.js
@@ -104,6 +104,7 @@ describe('Auth Controller - Login', () => {
     expect(res.json).toHaveBeenCalledWith({
       success: true,
       message: 'Login successful',
+      redirect: '/dashboard',
       user: {
         id: 1,
         email: 'test@example.com',


### PR DESCRIPTION
## Summary
- persist JWT tokens in secure cookies when logging in
- document the change in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688019bf0dd88320821169681b0df5d3